### PR TITLE
fix: switch to using otp code instead of magic link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,11 +11,11 @@ repos:
         files: '.env.development|.env.staging|.env.production'
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.7
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.32
+    rev: v3.95.9
     hooks:
       - id: trufflehog

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/node": "^22.13.5",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
-    "cheerio": "^1.1.2",
     "dotenv": "^17.4.2",
     "eslint": "^9.21.0",
     "eslint-config-standard-with-typescript": "^43.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,16 @@
-import { defineConfig, devices } from '@playwright/test'
-import dotenv from 'dotenv'
-import path from 'path'
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
 
 // PLAYWRIGHT_ENV selects .env.development, .env.staging, .env.production, etc.
-const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? 'development'
-const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`)
-dotenv.config({ path: envFile })
+const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? 'development';
+const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`);
+dotenv.config({ path: envFile });
 dotenv.config({ path: ".env" });
+dotenv.config({ quiet: true });
 
 // See https://playwright.dev/docs/test-configuration.
-const onCI = (process.env.CI ?? 'false') === 'true'
+const onCI = (process.env.CI ?? 'false') === 'true';
 export default defineConfig({
   testDir: './tests',
   // Serial execution: login uses one EMAIL_ADDRESS + S3 inbox + distributed lock; parallel workers cause timeouts.
@@ -27,4 +28,4 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] }
     }
   ]
-})
+});

--- a/tests/createCustomerApiKey.spec.ts
+++ b/tests/createCustomerApiKey.spec.ts
@@ -19,7 +19,7 @@ test('creating, using and revoking a customer api key', async ({ page }) => {
     expectFailure: false
   }
 
-  // 1. Log in (passwordless email; dev may show "Use real identity service" first)
+  // 1. Log in
   await loginPage.login()
 
   // 2. Create a new API key and remember it

--- a/tests/createTradeTariffCustomerApiKey.spec.ts
+++ b/tests/createTradeTariffCustomerApiKey.spec.ts
@@ -14,7 +14,7 @@ test('creating, revoking and deleting a trade tariff key', async ({ page }) => {
 
   const keyDescription = `playwright-trade-tariff-${Date.now()}`
 
-  // 1. Log in (passwordless email; dev may show "Use real identity service" first)
+  // 1. Log in
   await loginPage.login()
 
   // 2. Create a new Trade Tariff key and ensure the secret was captured

--- a/tests/pages/loginPage.ts
+++ b/tests/pages/loginPage.ts
@@ -3,22 +3,13 @@ import { type Page, type Locator, expect } from '@playwright/test'
 import EmailFetcher, { type EmailData } from '../utils/emailFetcher.js'
 import S3Lock from '../utils/s3Lock.js'
 
-/**
- * Login uses passwordless email flow in all environments (dev and staging):
- * - Click "Start now".
- * - In dev: land on dev login page → click "Use real identity service" → email page.
- * - In staging: go straight to email page.
- * - Then enter email, receive link from SES, follow link.
- */
 export class LoginPage {
   private static readonly STARTING_URL = process.env.URL ?? 'https://hub.dev.trade-tariff.service.gov.uk'
   private static readonly EMAIL_ADDRESS = process.env.EMAIL_ADDRESS ?? ''
   private static readonly INBOUND_BUCKET = process.env.INBOUND_BUCKET ?? ''
   private static readonly LOCK_KEY = process.env.LOCK_KEY ?? ''
 
-  /** Max time to wait for passwordless login email (ms). */
   private static readonly EMAIL_WAIT_MS = 20 * 1000
-  /** Poll interval while waiting for email (ms). */
   private static readonly EMAIL_POLL_MS = 1 * 1000
 
   private readonly page: Page
@@ -39,10 +30,8 @@ export class LoginPage {
     );
   }
 
-  /**
-   * Log in via passwordless email (same flow in dev and staging).
-   * Requires URL, EMAIL_ADDRESS, INBOUND_BUCKET, and LOCK_KEY to be set in env.
-   */
+  // Log in via passwordless email
+  // Requires URL, EMAIL_ADDRESS, INBOUND_BUCKET, and LOCK_KEY to be set in env
   async login(): Promise<Page> {
     this.requireEnvForLogin()
 
@@ -55,7 +44,6 @@ export class LoginPage {
     return this.page
   }
 
-  /** Fail fast with a clear message if required env vars are missing. */
   private requireEnvForLogin(): void {
     const missing: string[] = []
     if (!LoginPage.STARTING_URL) missing.push('URL')
@@ -80,19 +68,8 @@ export class LoginPage {
     await this.page.goto(LoginPage.STARTING_URL)
     await this.startNowButton().waitFor({ state: 'visible' })
 
-    // Click "Start now" → dev shows dev login page; staging goes straight to identity email page
     await this.startNowButton().click()
     await this.waitForLoginEntryPoint()
-
-    // In dev only: dev login page has "Use real identity service" → click to reach email page
-    const useRealIdentity = this.page.getByRole('link', { name: /use real identity service/i })
-      .or(this.page.getByRole('button', { name: /use real identity service/i }))
-    try {
-      await useRealIdentity.first().click({ timeout: 3000 })
-      await this.waitForEmailInput()
-    } catch {
-      // Staging: button not present, we're already on the email page
-    }
 
     await this.waitForEmailInput()
     this.assertOnLoginPage()
@@ -105,9 +82,10 @@ export class LoginPage {
         : this.page.locator('input[type="email"]').first()
 
       await emailInput.fill(LoginPage.EMAIL_ADDRESS)
-      await this.continueButton().click()
+      await this.continueButton().click();
       await this.waitForEmail();
-      await this.verifyPasswordlessLinkFromEmail();
+      await this.enterCodeFromEmail();
+      await this.continueButton().click();
     });
   }
 
@@ -150,6 +128,10 @@ export class LoginPage {
     return this.page.getByRole('link', { name: 'Sign Out' })
   }
 
+  private otpFirstDigitInput(): Locator {
+    return this.page.locator('input[aria-label="Digit 1 of 6"]')
+  }
+
   private async waitForEmail() {
     const startTime = Date.now();
 
@@ -168,16 +150,13 @@ export class LoginPage {
     throw new Error(`No email received within ${LoginPage.EMAIL_WAIT_MS}ms`);
   }
 
-  async verifyPasswordlessLinkFromEmail() {
-    if (
-      !this.email ||
-      !this.email.whitelistedLinks ||
-      this.email.whitelistedLinks.length === 0
-    ) {
-      throw new Error("No valid email links found");
-    }
+  private async enterCodeFromEmail() {
+    if (!this.email || !this.email.code) {
+      throw new error("No OTP code found");
 
-    const link = this.email.whitelistedLinks[0];
-    await this.page.goto(link);
+      const code = this.email.code;
+      await this.otpFirstDigitInput().click();
+      await this.otpFirstDigitInput().pressSequentially(code);
+    }
   }
 }

--- a/tests/pages/loginPage.ts
+++ b/tests/pages/loginPage.ts
@@ -94,13 +94,10 @@ export class LoginPage {
   }
 
   private async waitForLoginEntryPoint(): Promise<void> {
-    const useRealIdentity = this.page.getByRole('link', { name: /use real identity service/i })
-      .or(this.page.getByRole('button', { name: /use real identity service/i }))
     const specificEmailInput = this.page.locator('input[name="passwordless_form[email]"]')
     const genericEmailInput = this.page.locator('input[type="email"]').first()
 
     await Promise.race([
-      useRealIdentity.first().waitFor({ state: 'visible', timeout: 15_000 }),
       specificEmailInput.waitFor({ state: 'visible', timeout: 15_000 }),
       genericEmailInput.waitFor({ state: 'visible', timeout: 15_000 }),
       this.page.waitForURL(/\/dev\/login|\/login/, { timeout: 15_000 }),
@@ -152,11 +149,11 @@ export class LoginPage {
 
   private async enterCodeFromEmail() {
     if (!this.email || !this.email.code) {
-      throw new error("No OTP code found");
-
-      const code = this.email.code;
-      await this.otpFirstDigitInput().click();
-      await this.otpFirstDigitInput().pressSequentially(code);
+      throw new Error("No OTP code found");
     }
+
+    const code = this.email.code;
+    await this.otpFirstDigitInput().click();
+    await this.otpFirstDigitInput().pressSequentially(code);
   }
 }

--- a/tests/utils/emailFetcher.ts
+++ b/tests/utils/emailFetcher.ts
@@ -7,9 +7,7 @@ import {
   _Object,
   GetObjectOutput,
 } from "@aws-sdk/client-s3";
-import { URL } from "url";
 import { simpleParser, ParsedMail } from "mailparser";
-import { load } from "cheerio";
 
 export interface EmailData {
   from: string;
@@ -58,9 +56,9 @@ export default class EmailFetcher {
         emailData &&
         emailData.to.toLowerCase().includes(this.recipient.toLowerCase())
       ) {
-        const whitelistedLinks = this.getWhitelistedLinks(emailData);
-        if (whitelistedLinks.length > 0) {
-          emailData.whitelistedLinks = whitelistedLinks;
+        const code = this.extractCode(emailData);
+        if (code) {
+          emailData.code = code;
           email = emailData;
           break;
         }
@@ -111,35 +109,11 @@ export default class EmailFetcher {
     }
   }
 
-  private extractLinks(emailObj: EmailData): string[] {
+  private extractCode(emailObj: EmailData): string[] {
     if (!emailObj || !emailObj.body) return [];
-    const $ = load(emailObj.body);
-    const anchorLinks = $("a")
-      .map((_i, el) => $(el).attr("href"))
-      .get()
-      .filter((href): href is string => Boolean(href));
-    const plainLinks = [
-      ...emailObj.body.matchAll(/(https?:\/\/[^\s<>"']+)/gi),
-    ].map((m) => m[1]);
-    return [...new Set([...anchorLinks, ...plainLinks])];
-  }
+    const codeRegex = /(\d{6})/;
+    const emailCode: string[] = [...emailObj.body.matchAll(codeRegex)].map((m) => m[1])
 
-  private getWhitelistedLinks(emailObj: EmailData): string[] {
-    const encodedEmail = encodeURIComponent(this.recipient).replace(
-      /[-/\\^$*+?.()|[\]{}]/g,
-      "\\$&",
-    );
-    const callbackRegex = new RegExp(
-      `^(?:https?:\\/\\/)?(?:id\\.dev|id\\.staging)\\.trade-tariff\\.service\\.gov\\.uk\\/passwordless\\/callback\\?email=${encodedEmail}&token=[a-f0-9]{64}$`,
-    );
-    const allLinks = this.extractLinks(emailObj);
-    return allLinks.filter((link) => {
-      try {
-        return callbackRegex.test(new URL(link).href);
-      } catch (error) {
-        console.log(`Invalid URL in email`, error);
-        return false;
-      }
-    });
+    return emailCode;
   }
 }

--- a/tests/utils/emailFetcher.ts
+++ b/tests/utils/emailFetcher.ts
@@ -16,7 +16,7 @@ export interface EmailData {
   subject: string;
   body: string;
   s3_key: string;
-  whitelistedLinks?: string[];
+  code?: string;
 }
 
 export default class EmailFetcher {
@@ -109,11 +109,11 @@ export default class EmailFetcher {
     }
   }
 
-  private extractCode(emailObj: EmailData): string[] {
-    if (!emailObj || !emailObj.body) return [];
-    const codeRegex = /(\d{6})/;
+  private extractCode(emailObj: EmailData): string {
+    if (!emailObj || !emailObj.body) return "";
+    const codeRegex = /(?:Enter this code to log in: )(\d{6})/g;
     const emailCode: string[] = [...emailObj.body.matchAll(codeRegex)].map((m) => m[1])
 
-    return emailCode;
+    return emailCode[0] || "";
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,11 +721,6 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
-
 bowser@^2.11.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.12.1.tgz#f9ad78d7aebc472feb63dd9635e3ce2337e0e2c1"
@@ -799,35 +794,6 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-cheerio-select@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
-  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
-  dependencies:
-    boolbase "^1.0.0"
-    css-select "^5.1.0"
-    css-what "^6.1.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.0.1"
-
-cheerio@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.1.2.tgz#26af77e89336c81c63ea83197f868b4cbd351369"
-  integrity sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==
-  dependencies:
-    cheerio-select "^2.1.0"
-    dom-serializer "^2.0.0"
-    domhandler "^5.0.3"
-    domutils "^3.2.2"
-    encoding-sniffer "^0.2.1"
-    htmlparser2 "^10.0.0"
-    parse5 "^7.3.0"
-    parse5-htmlparser2-tree-adapter "^7.1.0"
-    parse5-parser-stream "^7.1.2"
-    undici "^7.12.0"
-    whatwg-mimetype "^4.0.0"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -853,22 +819,6 @@ cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-css-select@^5.1.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
-  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
-
-css-what@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
-  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 data-view-buffer@^1.0.2:
   version "1.0.2"
@@ -981,7 +931,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-domutils@^3.0.1, domutils@^3.2.1, domutils@^3.2.2:
+domutils@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
@@ -1009,14 +959,6 @@ encoding-japanese@2.2.0:
   resolved "https://registry.yarnpkg.com/encoding-japanese/-/encoding-japanese-2.2.0.tgz#0ef2d2351250547f432a2dd155453555c16deb59"
   integrity sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==
 
-encoding-sniffer@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz#396ec97ac22ce5a037ba44af1992ac9d46a7b819"
-  integrity sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==
-  dependencies:
-    iconv-lite "^0.6.3"
-    whatwg-encoding "^3.1.1"
-
 enhanced-resolve@^5.17.1:
   version "5.18.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz#728ab082f8b7b6836de51f1637aab5d3b9568faf"
@@ -1029,11 +971,6 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
-
-entities@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
-  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9:
   version "1.23.9"
@@ -1592,16 +1529,6 @@ html-to-text@9.0.5:
     htmlparser2 "^8.0.2"
     selderee "^0.11.0"
 
-htmlparser2@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.0.0.tgz#77ad249037b66bf8cc99c6e286ef73b83aeb621d"
-  integrity sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-    domutils "^3.2.1"
-    entities "^6.0.0"
-
 htmlparser2@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
@@ -1612,7 +1539,7 @@ htmlparser2@^8.0.2:
     domutils "^3.0.1"
     entities "^4.4.0"
 
-iconv-lite@0.6.3, iconv-lite@^0.6.3:
+iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -2015,13 +1942,6 @@ nodemailer@7.0.13:
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-7.0.13.tgz#74acaa55f0c6f9476384c29f27f53e467e8483cd"
   integrity sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==
 
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
-  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
-  dependencies:
-    boolbase "^1.0.0"
-
 object-inspect@^1.13.3:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
@@ -2114,28 +2034,6 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
-
-parse5-htmlparser2-tree-adapter@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz#b5a806548ed893a43e24ccb42fbb78069311e81b"
-  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
-  dependencies:
-    domhandler "^5.0.3"
-    parse5 "^7.0.0"
-
-parse5-parser-stream@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz#d7c20eadc37968d272e2c02660fff92dd27e60e1"
-  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
-  dependencies:
-    parse5 "^7.0.0"
-
-parse5@^7.0.0, parse5@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
-  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
-  dependencies:
-    entities "^6.0.0"
 
 parseley@^0.12.0:
   version "0.12.1"
@@ -2610,29 +2508,12 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici@^7.12.0:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
-
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-whatwg-encoding@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
-  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
-  dependencies:
-    iconv-lite "0.6.3"
-
-whatwg-mimetype@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
-  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Switched from verifying a magic link to using an OTP code
- Removed cruft about a dev bypass login that isn't there anymore

### Why?

I am doing this because:

- I'm cleaning up the E2E suites (see https://github.com/trade-tariff/trade-tariff-e2e-tests/pull/125) after changes were made to code without test changes