### PR TITLE
Fix TypeScript typecheck after dependency bumps

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -33,6 +33,8 @@ jobs:
 
       - run: yarn run lint
 
+      - run: yarn run typecheck
+
   run-tests:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-fpo-tests.yml@main
     with:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,16 @@ import tseslint from "typescript-eslint";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "playwright-report/**",
+      "test-results/**",
+      "blob-report/**",
+      "playwright/.cache/**",
+    ],
+  },
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@aws-sdk/client-s3": "^3.1083.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
+    "@types/mailparser": "3.4.6",
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
@@ -26,6 +27,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "fix": "eslint . --ext .ts --fix",
+    "typecheck": "tsc --noEmit",
     "test": "playwright test",
     "test-development": "PLAYWRIGHT_ENV=development playwright test",
     "test-staging": "PLAYWRIGHT_ENV=staging playwright test",

--- a/tests/utils/apiClient.ts
+++ b/tests/utils/apiClient.ts
@@ -5,6 +5,14 @@ export interface Classifiable {
   expectFailure?: boolean
 }
 
+interface ClassificationResult {
+  code: string
+}
+
+interface ClassificationResponse {
+  results?: ClassificationResult[]
+}
+
 interface HandleResponseOptions {
   requestOptions: RequestInit
   expectFailure: boolean
@@ -94,9 +102,9 @@ export class ApiClient {
   }
 
   assertClassification(expectedClassification: string): void {
-    const data = this.json ?? {}
-    const results = data?.results ?? []
-    const matchedResult = results.find((result: unknown) => result.code === expectedClassification)
+    const data = (this.json ?? {}) as ClassificationResponse
+    const results = data.results ?? []
+    const matchedResult = results.find((result) => result.code === expectedClassification)
     expect(matchedResult).toBeDefined()
   }
 

--- a/tests/utils/emailFetcher.ts
+++ b/tests/utils/emailFetcher.ts
@@ -7,7 +7,7 @@ import {
   _Object,
   GetObjectOutput,
 } from "@aws-sdk/client-s3";
-import { simpleParser, ParsedMail } from "mailparser";
+import { simpleParser, AddressObject, ParsedMail } from "mailparser";
 
 export interface EmailData {
   from: string;
@@ -17,6 +17,29 @@ export interface EmailData {
   body: string;
   s3_key: string;
   code?: string;
+}
+
+/** Subset of the AWS SdkStream mixin present on S3 GetObject bodies at runtime. */
+interface TransformableBody {
+  transformToString: (encoding?: string) => Promise<string>;
+}
+
+function addressText(address: AddressObject | AddressObject[] | undefined): string {
+  if (!address) {
+    return "Unknown";
+  }
+  if (Array.isArray(address)) {
+    return address.map((entry) => entry.text).filter(Boolean).join(", ") || "Unknown";
+  }
+  return address.text || "Unknown";
+}
+
+function hasTransformToString(body: unknown): body is TransformableBody {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    typeof (body as TransformableBody).transformToString === "function"
+  );
 }
 
 export default class EmailFetcher {
@@ -86,19 +109,20 @@ export default class EmailFetcher {
     if (!Body) {
       return null;
     }
-    const chunks: Uint8Array[] = [];
-    for await (const chunk of Body) {
-      chunks.push(chunk);
+    // GetObjectOutput types Body without the runtime SdkStream mixin methods.
+    // In Node the client always attaches transformToString; guard rather than cast.
+    if (!hasTransformToString(Body)) {
+      throw new Error(`S3 body for ${key} does not support transformToString`);
     }
-    const rawEmail = Buffer.concat(chunks).toString("utf-8");
+    const rawEmail = await Body.transformToString("utf-8");
     return this._parseMime(rawEmail, key);
   }
 
   private async _parseMime(rawEmail: string, key: string): Promise<EmailData | null> {
     try {
       const parsed: ParsedMail = await simpleParser(rawEmail);
-      const from = parsed.from?.text || "Unknown";
-      const to = parsed.to?.text || "Unknown";
+      const from = addressText(parsed.from);
+      const to = addressText(parsed.to);
       const subject = parsed.subject || "No Subject";
       const send_date = parsed.date || new Date();
       const body = parsed.html || parsed.textAsHtml || parsed.text || "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,6 +432,21 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/mailparser@3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@types/mailparser/-/mailparser-3.4.6.tgz#fcca99fe9f919f3da691a0bf5e3022c6283c3068"
+  integrity sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==
+  dependencies:
+    "@types/node" "*"
+    iconv-lite "^0.6.3"
+
+"@types/node@*":
+  version "26.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.2.tgz#da79708f1f9c6294f4cdec8f455a3032b028808a"
+  integrity sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==
+  dependencies:
+    undici-types "~8.3.0"
+
 "@types/node@^26.1.1":
   version "26.1.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.1.tgz#bad758d601e97d6cf457d204ee76a35fce7bd119"
@@ -1566,6 +1581,13 @@ iconv-lite@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
   integrity sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 


### PR DESCRIPTION
### Jira link

No ticket — follow-up after Dependabot TypeScript / ESLint major bumps.

### What?

- [x] Fix `tsc --noEmit` failures in `apiClient` and `emailFetcher` (typed classification payload, mailparser address handling, S3 body `transformToString`)
- [x] Add `@types/mailparser`
- [x] Add `yarn typecheck` script and run it in CI
- [x] Ignore Playwright report/output dirs in ESLint so local `yarn lint` matches CI

### Why?

We landed TypeScript 6 and related dependency bumps without verifying that `tsc` still typechecks. It did not — and CI never ran typecheck, so the breakage stayed invisible. This restores a green typecheck path and gates it in CI so the next bump cannot ignore it.